### PR TITLE
remove gcloud commands from minikube invocations

### DIFF
--- a/apps/admin/kubernetes/Makefile
+++ b/apps/admin/kubernetes/Makefile
@@ -31,7 +31,7 @@ app: build deploy
 main:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "$(BASEDIR)/../containers/main" "$(BASEDIR)/../containers/main.go" "$(BASEDIR)/../containers/kubernetes.go"	
 
-build: env creds main
+build: env main
 	gcloud container builds submit "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO)/admin
 
 deploy: env creds deployment service
@@ -61,4 +61,3 @@ retry: clean build deploy
 
 config: env 
 	echo "No custom config needed for admin"
-	

--- a/apps/api/kubernetes/Makefile
+++ b/apps/api/kubernetes/Makefile
@@ -30,7 +30,7 @@ reset.safe: env creds
 main:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "$(BASEDIR)/../containers/main" "$(BASEDIR)/../containers/main.go"
 
-build: env creds main
+build: env main
 	gcloud container builds submit "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO)/api
 
 deploy: env creds deployment service

--- a/apps/game/kubernetes/Makefile
+++ b/apps/game/kubernetes/Makefile
@@ -27,7 +27,7 @@ reset.safe: env creds
 	kubectl run game-deployment --image=$(DOCKERREPO)/game --replicas=4 --port=8080 --labels=app=game 
 	say "app refresh complete"	
 
-build: env creds
+build: env
 	gcloud container builds submit "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO)/game
 
 deploy: env creds deployment service
@@ -53,4 +53,4 @@ clean.service:
 
 retry: clean build deploy
 
-config: env 
+config: env

--- a/apps/ingress/Makefile
+++ b/apps/ingress/Makefile
@@ -27,11 +27,11 @@ config: env
 	$(call rewritefile,"$(BASEDIR)/ingress.yaml",%INGRESSNAME%,$(INGRESSNAME))
 
 clean: env creds
-	-kubectl delete -f "$(BASEDIR)/ingress.minikube.yaml"	
+	-kubectl delete -f "$(BASEDIR)/ingress.yaml"
 
 
 clean.minikube: 
-	-kubectl delete -f "$(BASEDIR)/ingress.yaml"
+	-kubectl delete -f "$(BASEDIR)/ingress.minikube.yaml"
 
 define rewritefile
 	@sed s/$(2)/$(3)/g <""$(1)"" >"$(BASEDIR)/.temp"


### PR DESCRIPTION
We don't need a Container Engine cluster (make creds) to build containers.

Also, the ingress Makefile was doing the minikube delete for GKE, and the GKE delete for minikube.