### PR TITLE
Enabled deploying on a local MiniKube cluster correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,23 @@ deploy.minikube: creds.minikube
 	cd "$(BASEDIR)/apps/api/kubernetes/" && $(MAKE) deploy.minikube
 	cd "$(BASEDIR)/apps/game/kubernetes/" && $(MAKE) deploy.minikube
 	cd "$(BASEDIR)/apps/admin/kubernetes/" && $(MAKE) deploy.minikube
-	cd "$(BASEDIR)/apps/ingress/" && $(MAKE) deploy.minikube	
+	cd "$(BASEDIR)/apps/ingress/" && $(MAKE) deploy.minikube
+
+deploy.minikube.dockerhub: creds.minikube
+	minikube addons enable ingress
+	cd "$(BASEDIR)/apps/api/kubernetes/" && $(MAKE) deploy.minikube.dockerhub
+	cd "$(BASEDIR)/apps/game/kubernetes/" && $(MAKE) deploy.minikube.dockerhub
+	cd "$(BASEDIR)/apps/admin/kubernetes/" && $(MAKE) deploy.minikube.dockerhub
+	cd "$(BASEDIR)/apps/ingress/" && $(MAKE) deploy.minikube
+	@printf -- "*** DONE ***\n"
+	@printf -- "add the following line to your /etc/hosts file:\n\n"
+	@printf -- "$(shell minikube ip) minikube.wap\n\n"
 
 deploy.generic: 
 	cd "$(BASEDIR)/apps/api/kubernetes/" && $(MAKE) deploy.generic
 	cd "$(BASEDIR)/apps/game/kubernetes/" && $(MAKE) deploy.generic
 	cd "$(BASEDIR)/apps/admin/kubernetes/" && $(MAKE) deploy.generic
 	cd "$(BASEDIR)/apps/ingress/" && $(MAKE) deploy.generic
-	
 
 clean: env creds
 	cd "$(BASEDIR)/apps/api/kubernetes/" && $(MAKE) clean
@@ -57,10 +66,21 @@ clean.minikube:
 	cd "$(BASEDIR)/apps/admin/kubernetes/" && $(MAKE) clean.minikube	
 	cd "$(BASEDIR)/apps/ingress/" && $(MAKE) clean.minikube
 
+clean.minikube.dockerhub: 
+	cd "$(BASEDIR)/apps/api/kubernetes/" && $(MAKE) clean.minikube
+	cd "$(BASEDIR)/apps/game/kubernetes/" && $(MAKE) clean.minikube
+	cd "$(BASEDIR)/apps/admin/kubernetes/" && $(MAKE) clean.minikube.dockerhub
+	cd "$(BASEDIR)/apps/ingress/" && $(MAKE) clean.minikube
+
 build: env creds
 	cd "$(BASEDIR)/apps/api/kubernetes/" && $(MAKE) build
 	cd "$(BASEDIR)/apps/game/kubernetes/" && $(MAKE) build
-	cd "$(BASEDIR)/apps/admin/kubernetes/" && $(MAKE) build		
+	cd "$(BASEDIR)/apps/admin/kubernetes/" && $(MAKE) build
+
+build.dockerhub:
+	cd "$(BASEDIR)/apps/api/kubernetes/" && $(MAKE) build.dockerhub
+	cd "$(BASEDIR)/apps/game/kubernetes/" && $(MAKE) build.dockerhub
+	cd "$(BASEDIR)/apps/admin/kubernetes/" && $(MAKE) build.dockerhub
 
 build.generic: 
 	cd "$(BASEDIR)/apps/api/kubernetes/" && $(MAKE) build.generic

--- a/README.md
+++ b/README.md
@@ -117,14 +117,41 @@ This still requires a Google Cloud Platform Project.  If you would like to build
 them some other way, you can, nothing restricts you from doing so. Just make 
 sure you set `$(DOCKERREPO)` to the right value in Makefile.properties.
 
+#### Docker Repository with DockerHub 
+Alternatively, to host your images on DockerHub,
+
+1. Create an account on DockerHub
+2. Create an image repository on DockerHub
+3. In the `Makefile.properties`, change the value of `PROJECT` so that it equals your image repository slug
+4. In the `Makefile.properties`, change the value of `DOCKERREPO` so that it looks like `yourusername/$(PROJECT)`
+5. Run `make build.dockerhub`
+
+Your repository should have three new images with the tags:
+- admin
+- api
+- game
+
+For example, if your username is `username` and your repository name is `wap`, your images will be pushed to:
+- username/wap:admin
+- username/wap:api
+- username/wap:game
 
 ### Running on Minikube
 
 1. Open a terminal in root of whack_a_pod location.
 1. Run `minikube start --vm-driver=xhyve`
 1. Run `make deploy.minikube`
-1. Run `kubectl describe ingress` to get the IP address of the ingress.
-1. Create an entry in /etc/hosts pointing IP address to `minikube.wap`.   
+1. Run `minikube ip` to get the IP address of the Minikube deployment.
+1. Create an entry in /etc/hosts pointing IP address to `minikube.wap`.
+
+### Running on Minikube with DockerHub
+1. Open a terminal in root of whack_a_pod location.
+1. Run `minikube start`
+1. Run `make deploy.minikube.dockerhub`
+1. The last line of the previous command should contain an IP address beside a `"minikube.wap"` string
+1. Run `sudo vim /etc/hosts`, append the last line to the `/etc/hosts` and save the file.
+1. Wait for the ingress to obtain an IP address (run `kubectl get ing --watch` and wait till the `ADDRESS` column has a value)
+1. Visit [http://minikube.wap](http://minikube.wap) in the browser
 
 ### Clean Minikube
 1. Run `make clean.minikube`

--- a/apps/admin/kubernetes/Makefile
+++ b/apps/admin/kubernetes/Makefile
@@ -29,10 +29,15 @@ reset.safe:
 app: build deploy
 
 main:
+	go get github.com/gorilla/mux
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "$(BASEDIR)/../containers/main" "$(BASEDIR)/../containers/main.go" "$(BASEDIR)/../containers/kubernetes.go"	
 
 build: env main
 	gcloud container builds submit "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO)/admin
+
+build.dockerhub: main
+	docker build "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO):admin
+	docker push $(DOCKERREPO):admin
 
 build.generic: main
 	docker build "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO)/whackapod-admin
@@ -41,13 +46,21 @@ build.generic: main
 deploy: env creds deployment service
 
 deploy.minikube: deployment service
-deploy.generic: 
+	
+deploy.minikube.dockerhub:
+	kubectl run admin-deployment --image=$(DOCKERREPO):admin --replicas=1 --port=8080 --labels=app=admin --env="APIIMAGE=$(DOCKERREPO):api"
+	kubectl expose deployment admin-deployment --name=admin --target-port=8080  --type=NodePort --labels="app=admin"
+	kubectl create serviceaccount wap-admin
+	kubectl create clusterrolebinding wap-admin --clusterrole=cluster-admin --serviceaccount=default:wap-admin
+	kubectl set serviceaccount deployment admin-deployment wap-admin
+
+deploy.generic:
 	kubectl run admin-deployment --image=$(DOCKERREPO)/whackapod-admin --replicas=1 --port=8080 --labels=app=admin --env="APIIMAGE=$(DOCKERREPO)/whackapod-api"
 	kubectl expose deployment admin-deployment --name=admin --target-port=8080  --type=NodePort --labels="app=admin"
 	kubectl create serviceaccount wap-admin	
 	kubectl create clusterrolebinding wap-admin --clusterrole=cluster-admin --serviceaccount=$$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"$$(kubectl config current-context)\")].context.namespace}"):wap-admin
 	kubectl set serviceaccount deployment admin-deployment wap-admin
-	
+
 test: 
 	cd 	"$(BASEDIR)/../containers" && go test
 
@@ -59,7 +72,11 @@ service:
 
 clean: env creds clean.deployment clean.service 
 
-clean.minikube: clean.deployment clean.service 
+clean.minikube: clean.deployment clean.service
+
+clean.minikube.dockerhub: clean.deployment clean.service
+	-kubectl delete serviceaccount wap-admin
+	-kubectl delete clusterrolebinding wap-admin 
 
 clean.deployment: 
 	-kubectl delete deployment admin-deployment

--- a/apps/api/kubernetes/Makefile
+++ b/apps/api/kubernetes/Makefile
@@ -33,6 +33,10 @@ main:
 build: env main
 	gcloud container builds submit "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO)/api
 
+build.dockerhub: main
+	docker build "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO):api
+	docker push $(DOCKERREPO):api
+
 build.generic: main
 	docker build "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO)/whackapod-api
 	docker push $(DOCKERREPO)/whackapod-api
@@ -40,6 +44,10 @@ build.generic: main
 deploy: env creds deployment service
 
 deploy.minikube: deployment service
+
+deploy.minikube.dockerhub:
+	kubectl run api-deployment --image=$(DOCKERREPO):api --replicas=12 --port=8080 --labels=app=api
+	kubectl expose deployment api-deployment --name=api --target-port=8080  --type=NodePort --labels="app=api"
 
 deploy.generic: 
 	kubectl run api-deployment --image=$(DOCKERREPO)/whackapod-api --replicas=12 --port=8080 --labels=app=api 

--- a/apps/game/kubernetes/Makefile
+++ b/apps/game/kubernetes/Makefile
@@ -30,6 +30,10 @@ reset.safe: env creds
 build: env
 	gcloud container builds submit "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO)/game
 
+build.dockerhub:
+	docker build "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO):game
+	docker push $(DOCKERREPO):game
+
 build.generic: 
 	docker build "$(BASEDIR)/../containers/." --tag=$(DOCKERREPO)/whackapod-game
 	docker push $(DOCKERREPO)/whackapod-game
@@ -38,19 +42,23 @@ deploy: env creds deployment service
 
 deploy.minikube: deployment service
 
+deploy.minikube.dockerhub:
+	kubectl run game-deployment --image=$(DOCKERREPO):game --replicas=4 --port=8080 --labels=app=game 
+	kubectl expose deployment game-deployment --name=game --target-port=8080  --type=NodePort --labels="app=game"
+
 deploy.generic: 
 	kubectl run game-deployment --image=$(DOCKERREPO)/whackapod-game --replicas=4 --port=8080 --labels=app=game 
-	kubectl expose deployment game-deployment --name=game --target-port=8080  --type=NodePort --labels="app=api"
+	kubectl expose deployment game-deployment --name=game --target-port=8080  --type=NodePort --labels="app=game"
 
 deployment:
 	kubectl run game-deployment --image=$(DOCKERREPO)/game --replicas=4 --port=8080 --labels=app=game 
 
 service:
-	kubectl expose deployment game-deployment --name=game --target-port=8080  --type=NodePort --labels="app=api"
+	kubectl expose deployment game-deployment --name=game --target-port=8080  --type=NodePort --labels="app=game"
 
 clean: env creds clean.deployment clean.service 
 
-clean.generic: clean.deployment clean.service 
+clean.generic: clean.deployment clean.service
 
 clean.minikube: clean.deployment clean.service 
 

--- a/apps/ingress/Makefile
+++ b/apps/ingress/Makefile
@@ -18,10 +18,10 @@ include ../../Makefile.properties
 deploy: env creds
 	kubectl apply -f "$(BASEDIR)/ingress.yaml"
 
-deploy.minikube: 
-	kubectl apply -f "$(BASEDIR)/ingress.minikube.yaml"	
+deploy.minikube:
+	kubectl apply -f "$(BASEDIR)/ingress.minikube.yaml"
 
-deploy.generic: 
+deploy.generic:
 	kubectl apply -f "$(BASEDIR)/ingress.generic.yaml"	
 
 config: env
@@ -32,10 +32,10 @@ config: env
 clean: env creds
 	-kubectl delete -f "$(BASEDIR)/ingress.yaml"
 
-clean.minikube: 
+clean.minikube:
 	-kubectl delete -f "$(BASEDIR)/ingress.minikube.yaml"
 
-clean.generic: 
+clean.generic:
 	-kubectl delete -f "$(BASEDIR)/ingress.generic.yaml"
 
 define rewritefile

--- a/apps/ingress/ingress.minikube.yaml
+++ b/apps/ingress/ingress.minikube.yaml
@@ -22,15 +22,15 @@ spec:
   - host: minikube.wap
     http:
       paths:
-      - path: /api/*
+      - path: /api/
         backend:
           serviceName: api
           servicePort: 8080
-      - path: /admin/*
+      - path: /admin/
         backend:
           serviceName: admin
           servicePort: 8080
-      - path: /*
+      - path: /
         backend:
           serviceName: game
           servicePort: 8080


### PR DESCRIPTION
Enabled deploying on a local MiniKube cluster correctly and fixed minikube deployment

- added `build.dockerhub` make recipe
- added golang dependency retrieval
- fixed game service label so that `"app=game"` instead of `"app=api"` which led to errors
- added `deploy.minikube.dockerhub` make recipe
- fixed ingress paths for minikube to work

I think this addresses issue #4 too by adding instructions for changing the `DOCKERREPO` makefile property